### PR TITLE
Various fixes and small improvements

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,9 @@
 #!/bin/sh
-gcc `pkg-config --cflags gtk+-3.0` -Wall -fPIC -shared -ldl -o gtk3-nocsd.so gtk3-nocsd.c
+
+: ${PKG_CONFIG:=pkg-config}
+: ${CC:=cc}
+: ${CFLAGS:=-O2 -g}
+
+set -x
+
+${CC} `${PKG_CONFIG} --cflags gtk+-3.0` ${CPPFLAGS} ${CFLAGS} -Wall -fPIC -shared ${LDFLAGS} -ldl -o gtk3-nocsd.so gtk3-nocsd.c

--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,4 @@
 
 set -x
 
-${CC} `${PKG_CONFIG} --cflags gtk+-3.0` ${CPPFLAGS} ${CFLAGS} -Wall -fPIC -shared ${LDFLAGS} -ldl -o gtk3-nocsd.so gtk3-nocsd.c
+${CC} `${PKG_CONFIG} --cflags gtk+-3.0` ${CPPFLAGS} ${CFLAGS} -pthread -Wall -fPIC -shared ${LDFLAGS} -ldl -o gtk3-nocsd.so gtk3-nocsd.c

--- a/gtk3-nocsd.c
+++ b/gtk3-nocsd.c
@@ -39,7 +39,7 @@ typedef GObject* (*gtk_dialog_constructor_t) (GType type, guint n_construct_prop
 
 // When set to true, this override gdk_screen_is_composited() and let it
 // return FALSE temporarily. Then, client-side decoration (CSD) cannot be initialized.
-volatile static int disable_composite = 0;
+volatile static __thread int disable_composite = 0;
 
 static gboolean is_compatible_gtk_version() {
     static gboolean checked = FALSE;


### PR DESCRIPTION
I've fixed a couple of crashes when LD_PRELOADing this library and also made some small fixes:

 - fix crashes when plugins/modules linked against gtk2/gtk3 are used (e.g. pygtk)
 - remove duplicate close etc. buttons from the header bar when disabling CSD (WM provides those)
 - fix potential multithreading problem
 - make build.sh respect standard build environment variables (CC, CFLAGS, ...)

There are still two minor outstanding issues I know about (problems with popup menus and minimizing of dialogs), I'll have a look at themlater, but these here are the most important things.

/cc @xtaran