### PR TITLE
Add wrapper script to set LD_PRELOAD on-demand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,20 @@ CFLAGS ?= -O2 -g
 CFLAGS += $(shell ${PKG_CONFIG} --cflags gtk+-3.0) -pthread -Wall -fPIC
 LDLIBS = -ldl
 
-libdir ?= /usr/lib
+prefix ?= /usr/local
+libdir ?= $(prefix)/lib
 
-all: libgtk3-nocsd.so.0
+all: libgtk3-nocsd.so.0 wrapper.sh
 
 clean:
-	rm -f libgtk3-nocsd.so.0 *.o *~
+	rm -f libgtk3-nocsd.so.0 *.o wrapper.sh *~
 
 libgtk3-nocsd.so.0: gtk3-nocsd.o
 	$(CC) -shared $(CFLAGS) $(LDFLAGS) -Wl,-soname,libgtk3-nocsd.so.0 -o $@ $^ $(LDLIBS)
+
+wrapper.sh: wrapper.sh.in
+	sed 's|@@libdir@@|$(libdir)|g' < $< > $@
+	chmod +x wrapper.sh
 
 install:
 	install -D -m 0644 libgtk3-nocsd.so.0 $(DESTDIR)$(libdir)/libgtk3-nocsd.so.0

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# wrapper.sh - Wrapper to apply gtk3-nocsd to application
+#
+# Usage: ln -s wrapper.sh ~/bin/evince
+#
+# Create a symlink to this wrapper script with the name of the program
+# you want run without client-side decorations. This wrapper script
+# will run the first matching executable in the PATH that is *not* a
+# script. This wrapper script is useful if you don't want to add
+# gtk3-nocsd to your system-wide LD_PRELOAD or if you only want it
+# applied to certain applications.
+#
+
+# Location of gtk3-nocsd library
+NOCSDLIB="/usr/local/lib/libgtk3-nocsd.so.0"
+if [ -z "$NOCSDLIB" ] || ! [ -e "$NOCSDLIB" ]; then
+    # Try looking in the same directory as the script
+    NOCSDLIB="$(dirname "$(readlink -f "$0")")/libgtk3-nocsd.so.0"
+fi
+export LD_PRELOAD="$NOCSDLIB:$LD_PRELOAD"
+export GTK_CSD=0
+
+# Find the real program (the first one that's not a shell script)
+APPNAME="$(basename "$0")"
+for APPPATH in $(type -Pa "$APPNAME") /bin/false; do
+    head -c2 "$APPPATH" | grep '#!' >/dev/null || break
+done
+
+# Run the program with CSD disabled
+exec "$APPPATH" "$@"


### PR DESCRIPTION
I'd like to have gtk3-nocsd in my LD_PRELOAD only for certain applications (i.e. the few GTK3 applications I use regularly), so I wrote this wrapper script. You can use it like this:

    ln -s ~/Downloads/gtk3-nocsd/wrapper.sh ~/bin/evince

Then whenever you run Evince (because `evince.desktop` doesn't have an absolute path), it will run without CSD automatically, but it won't affect any of your other applications. I hope you find this useful, and that packagers consider putting it in `/usr/share/doc/gtk3-nocsd` or something (I don't think it's good enough to ship in `/usr/bin`).

I also took the opportunity to adjust the Makefile to use a `prefix` variable, defaulting to `/usr/local`, since code shouldn't normally install itself into `/usr` unless compiled by your distributor.

Thanks!