### PR TITLE
Use the real SONAMEs of GObject and GLib

### DIFF
--- a/gtk3-nocsd.c
+++ b/gtk3-nocsd.c
@@ -57,11 +57,11 @@ enum {
 #endif
 
 #ifndef GOBJECT_LIBRARY_SONAME
-#define GOBJECT_LIBRARY_SONAME "libgobject-2.0.so"
+#define GOBJECT_LIBRARY_SONAME "libgobject-2.0.so.0"
 #endif
 
 #ifndef GLIB_LIBRARY_SONAME
-#define GLIB_LIBRARY_SONAME "libglib-2.0.so"
+#define GLIB_LIBRARY_SONAME "libglib-2.0.so.0"
 #endif
 
 #ifndef GIREPOSITORY_LIBRARY_SONAME


### PR DESCRIPTION
The symlinks with bare '.so' rather than '.so.0' are part of development packages, and are not intended to be installed on end-user systems.

This appears to have caused (or at least contributed to) <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=801350>.

---

This is entirely untested; I'm trying out github's in-browser editing :-)

See also <https://github.com/PCMan/gtk3-nocsd/issues/6#issuecomment-146811403>. @cassiodoroVicinetti, please try with this change?