### PR TITLE
Fix for return value of g_type_add_instance_private for gtk_header_bar

### DIFF
--- a/gtk3-nocsd.c
+++ b/gtk3-nocsd.c
@@ -1197,7 +1197,7 @@ gint g_type_add_instance_private (GType class_type, gsize private_size)
     } else if (G_UNLIKELY (class_type == gtk_header_bar_type && gtk_header_bar_private_size == 0)) {
         gtk_header_bar_private_size = private_size;
         gtk_header_bar_private_offset = orig_g_type_add_instance_private (class_type, private_size);
-        return gtk_window_private_offset;
+        return gtk_header_bar_private_offset;
     }
     return orig_g_type_add_instance_private (class_type, private_size);
 }


### PR DESCRIPTION
The   value    of   `gtk_window_private_offset`   was    returned   from
`g_type_add_instance_private`   for  `gtk_header_bar`   type  instead   of
`gtk_header_bar_private_offset`.